### PR TITLE
fix: handle list-shaped empty data in DTEK schedule feed

### DIFF
--- a/custom_components/svitlo_yeah/api/dtek/base.py
+++ b/custom_components/svitlo_yeah/api/dtek/base.py
@@ -167,7 +167,7 @@ class DtekAPIBase:
             '1761688800': {
                 'GPV1.1': {
         """
-        if not self.data or "data" not in self.data:
+        if not self.data or not isinstance(self.data.get("data"), dict):
             return []
 
         first_timestamp = next(iter(self.data["data"].values()), {})
@@ -185,7 +185,11 @@ class DtekAPIBase:
         self, start_date: datetime.datetime, end_date: datetime.datetime
     ) -> list[PlannedOutageEvent]:
         """Get all events within the date range."""
-        if not self.data or "data" not in self.data or not self.group:
+        if (
+            not self.data
+            or not isinstance(self.data.get("data"), dict)
+            or not self.group
+        ):
             return []
 
         events = []

--- a/tests/test_dtek_base.py
+++ b/tests/test_dtek_base.py
@@ -109,6 +109,11 @@ class TestDtekAPIBaseGroups:
         api.data = {"data": {}}
         assert api.get_dtek_region_groups() == []
 
+    def test_get_groups_list_shaped_data(self, api):
+        """Empty schedules arrive as a list ("data": []) — must not crash."""
+        api.data = {"data": [], "update": "29.06.2026 08:24", "today": True}
+        assert api.get_dtek_region_groups() == []
+
 
 class TestDtekAPIBaseParseGroupHours:
     """Test _parse_group_hours method."""
@@ -382,6 +387,21 @@ class TestDtekAPIBaseParsePresetGroupHours:
         """Test parsing various preset group hour patterns using the unified function."""
         result = _parse_group_hours(group_hours)
         assert result == expected
+
+
+class TestDtekAPIBaseEventsListShapedData:
+    """Regression: upstream feed serializes an empty schedule as "data": []."""
+
+    def test_get_events_list_shaped_data(self, api):
+        """get_events must return [] instead of raising AttributeError."""
+        api.data = {"data": [], "update": "29.06.2026 08:24", "today": True}
+        now = dt_utils.now()
+        assert api.get_events(now, now + datetime.timedelta(hours=24)) == []
+
+    def test_get_current_event_list_shaped_data(self, api):
+        """get_current_event must return None on list-shaped data."""
+        api.data = {"data": [], "update": "29.06.2026 08:24", "today": True}
+        assert api.get_current_event(dt_utils.now()) is None
 
 
 class TestDtekAPIBaseScheduledEvents:


### PR DESCRIPTION
## Problem

When no outages are scheduled, the JSON schedule feed (e.g. `outage-data-ua` kyiv-region.json) currently serializes an empty schedule as a **list**:

```json
"fact": { "data": [], "update": "29.06.2026 08:24", "today": [] }
```

`DtekAPIBase.get_events()` and `get_dtek_region_groups()` assume `data["data"]` is a dict, so every coordinator refresh raises:

```
File .../api/dtek/base.py, line 193, in get_events
    for timestamp_str, day_data in self.data["data"].items():
AttributeError: 'list' object has no attribute 'items'
```

On a 10-minute refresh interval this floods the HA log with ~144 errors/day per entry (observed 229/day with two coordinators) for as long as the grid has no planned outages.

## Fix

Guard both call sites with `isinstance(self.data.get("data"), dict)` so a list-shaped/empty payload yields no events and no groups instead of raising. Dict-shaped schedules are unaffected.

## Tests

Added three regression tests in `tests/test_dtek_base.py` covering `get_events`, `get_current_event`, and `get_dtek_region_groups` with `"data": []`. They fail with the AttributeError above before the fix and pass after; the full `test_dtek_base.py` suite stays green (44 passed).