### PR TITLE
fix: cancel boundary timer on entity removal (leak on every reload)

### DIFF
--- a/custom_components/svitlo_yeah/entity.py
+++ b/custom_components/svitlo_yeah/entity.py
@@ -73,6 +73,13 @@ class IntegrationEntity(CoordinatorEntity[IntegrationCoordinator]):
         self._update_active_state()
         self._schedule_next_boundary()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the scheduled boundary callback when the entity is removed."""
+        if self._unsubscribe_boundary:
+            self._unsubscribe_boundary()
+            self._unsubscribe_boundary = None
+        await super().async_will_remove_from_hass()
+
     def _update_active_state(self) -> None:
         """Recalculate active state from events."""
         if (event := self.coordinator.get_current_event()) != self._event:

--- a/tests/test_entity_boundary_timer.py
+++ b/tests/test_entity_boundary_timer.py
@@ -1,0 +1,20 @@
+"""Tests for boundary-timer lifecycle on entity removal."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.svitlo_yeah.calendar import PlannedOutagesCalendar
+
+
+@pytest.mark.asyncio
+async def test_boundary_timer_cancelled_on_remove():
+    """The scheduled boundary callback must be cancelled when the entity is removed."""
+    entity = object.__new__(PlannedOutagesCalendar)
+    unsubscribe = MagicMock()
+    entity._unsubscribe_boundary = unsubscribe
+
+    await entity.async_will_remove_from_hass()
+
+    unsubscribe.assert_called_once()
+    assert entity._unsubscribe_boundary is None


### PR DESCRIPTION
## Problem

`IntegrationEntity._schedule_next_boundary()` registers a self-perpetuating `async_track_point_in_time` callback (`_handle_boundary` reschedules itself), but nothing cancels it when the entity is removed — there is no `async_will_remove_from_hass` and the unsubscribe callable is never passed to `async_on_remove`.

Every config-entry reload (options change triggers one via the update listener, plus manual reloads) therefore leaks a zombie timer that keeps firing and rescheduling itself forever on a detached entity instance, calling `async_write_ha_state()` on an entity no longer registered. The set of leaked timers grows with every reload.

## Fix

Override `async_will_remove_from_hass` to cancel the scheduled callback before the entity detaches.

## Tests

Adds `tests/test_entity_boundary_timer.py`: fails before the fix (unsubscribe never called), passes after. Full suite green.
