### PR TITLE
fix: four schedule-data correctness defects (stale consent, month rollover, multi-day emergency, update-stamp timezone)

### DIFF
--- a/custom_components/svitlo_yeah/api/dtek/json.py
+++ b/custom_components/svitlo_yeah/api/dtek/json.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 
 import aiohttp
 
-from ...const import DTEK_FRESH_DATA_DAYS
+from ...const import DTEK_FRESH_DATA_DAYS, TZ_UA
 from .base import DtekAPIBase, FetchResult
 
 LOGGER = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def _parse_update_dt(update_dt: str | None) -> datetime | None:
         return None
     for fmt in _UPDATE_DATE_FORMATS:
         try:
-            return datetime.strptime(update_dt, fmt).astimezone(UTC)
+            return datetime.strptime(update_dt, fmt).replace(tzinfo=TZ_UA)
         except ValueError:
             continue
     return None

--- a/custom_components/svitlo_yeah/api/e_svitlo.py
+++ b/custom_components/svitlo_yeah/api/e_svitlo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -252,7 +252,7 @@ class ESvitloClient:
 
             # Handle end time on next day (e.g., 23:00-04:00)
             if end_time < start_time:
-                end_datetime = end_datetime.replace(day=end_datetime.day + 1)
+                end_datetime = end_datetime + timedelta(days=1)
 
             return PlannedOutageEvent(
                 start=start_datetime,

--- a/custom_components/svitlo_yeah/api/yasno.py
+++ b/custom_components/svitlo_yeah/api/yasno.py
@@ -357,7 +357,7 @@ class YasnoApi:
         """Get the current event."""
         all_events = self.get_events(at, at + timedelta(days=1))
         for event in all_events:
-            if event.all_day and event.start == at.date():
+            if event.all_day and event.start <= at.date() < event.end:
                 return event
             if not event.all_day and event.start <= at < event.end:
                 return event

--- a/custom_components/svitlo_yeah/config_flow.py
+++ b/custom_components/svitlo_yeah/config_flow.py
@@ -23,6 +23,7 @@ from .api.yasno import YASNO_REGIONS_ENDPOINT, YasnoApi
 from .const import (
     CONF_ACCOUNT_ID,
     CONF_ADDRESS_STR,
+    CONF_ALLOW_STALE_DATA,
     CONF_GROUP,
     CONF_PROVIDER,
     CONF_PROVIDER_TYPE,
@@ -148,7 +149,9 @@ class IntegrationConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             LOGGER.debug("async_step_group: User input: %s", user_input)
             self.data.update(user_input)  # add group to the config
-            self.data.pop("_stale_ack", None)  # flow-local flag, do not persist
+            if self.data.pop("_stale_ack", None):
+                # Persist the consent so polling can keep honoring it
+                self.data[CONF_ALLOW_STALE_DATA] = True
 
             LOGGER.info("async_step_group: Done. Creating entry from %s", self.data)
             # noinspection PyTypeChecker

--- a/custom_components/svitlo_yeah/const.py
+++ b/custom_components/svitlo_yeah/const.py
@@ -18,6 +18,7 @@ CONF_GROUP: Final = "group"
 CONF_ACCOUNT_ID: Final = "account_id"
 CONF_ADDRESS_STR: Final = "address_str"
 CONF_PROVIDER_TYPE: Final = "provider_type"
+CONF_ALLOW_STALE_DATA: Final = "allow_stale_data"
 
 # Provider types
 PROVIDER_TYPE_YASNO: Final = "yasno"

--- a/custom_components/svitlo_yeah/coordinator/dtek/base.py
+++ b/custom_components/svitlo_yeah/coordinator/dtek/base.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from homeassistant.util import dt as dt_utils
 
 from ...const import (
+    CONF_ALLOW_STALE_DATA,
     CONF_GROUP,
     CONF_PROVIDER,
     DEBUG,
@@ -86,7 +87,13 @@ class DtekCoordinatorBase(IntegrationCoordinator):
 
         # Coordinator-level caching (per provider)
         now = dt_utils.now()
-        await self.api.fetch_data()
+        allow_stale_data = bool(
+            self.config_entry.options.get(
+                CONF_ALLOW_STALE_DATA,
+                self.config_entry.data.get(CONF_ALLOW_STALE_DATA, False),
+            )
+        )
+        await self.api.fetch_data(allow_stale_data=allow_stale_data)
         LOGGER.debug("Fetched fresh data for %s", self)
 
         # Check if outage data has changed (used for last_data_change attribute)

--- a/tests/test_schedule_data_correctness.py
+++ b/tests/test_schedule_data_correctness.py
@@ -1,0 +1,104 @@
+"""Regression tests for schedule/data-correctness defects."""
+
+import time as time_module
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.svitlo_yeah.api.dtek.json import _parse_update_dt
+from custom_components.svitlo_yeah.api.e_svitlo import ESvitloClient
+from custom_components.svitlo_yeah.api.yasno import YasnoApi
+from custom_components.svitlo_yeah.const import TZ_UA
+from custom_components.svitlo_yeah.coordinator.dtek.json import DtekCoordinatorJson
+from custom_components.svitlo_yeah.models import (
+    PlannedOutageEvent,
+    PlannedOutageEventType,
+)
+
+
+class TestStaleConsentPropagation:
+    """The stale-data consent given during config flow must survive into polling."""
+
+    @pytest.mark.asyncio
+    async def test_coordinator_polls_with_stale_consent(self):
+        """A consented entry must poll with allow_stale_data=True."""
+        coordinator = object.__new__(DtekCoordinatorJson)
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.options = {}
+        coordinator.config_entry.data = {"allow_stale_data": True}
+        coordinator.api = MagicMock()
+        coordinator.api.fetch_data = AsyncMock()
+        coordinator.api.get_events = MagicMock(return_value=[])
+        coordinator.async_fetch_translations = AsyncMock()
+        coordinator.check_outage_data_changed = MagicMock()
+
+        await coordinator._async_update_data()
+
+        coordinator.api.fetch_data.assert_called_once_with(allow_stale_data=True)
+
+    @pytest.mark.asyncio
+    async def test_coordinator_defaults_to_fresh_only(self):
+        """Without consent the coordinator must not adopt stale data."""
+        coordinator = object.__new__(DtekCoordinatorJson)
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.options = {}
+        coordinator.config_entry.data = {}
+        coordinator.api = MagicMock()
+        coordinator.api.fetch_data = AsyncMock()
+        coordinator.api.get_events = MagicMock(return_value=[])
+        coordinator.async_fetch_translations = AsyncMock()
+        coordinator.check_outage_data_changed = MagicMock()
+
+        await coordinator._async_update_data()
+
+        coordinator.api.fetch_data.assert_called_once_with(allow_stale_data=False)
+
+
+class TestOvernightPeriodMonthRollover:
+    """Overnight periods on the last day of a month must roll into the next month."""
+
+    def test_parse_period_month_boundary(self):
+        """23:00-04:00 on Oct 31 must end on Nov 1, not raise ValueError."""
+        client = object.__new__(ESvitloClient)
+        period = {"start_time": "23:00", "end_time": "04:00"}
+
+        event = client._parse_period(period, date(2026, 10, 31))
+
+        assert event is not None
+        assert event.start == datetime(2026, 10, 31, 23, 0, tzinfo=TZ_UA)
+        assert event.end == datetime(2026, 11, 1, 4, 0, tzinfo=TZ_UA)
+
+
+class TestMultiDayAllDayCurrentEvent:
+    """A merged multi-day all-day event stays 'current' on its later days."""
+
+    def test_get_current_event_second_day(self):
+        """Day 2 of a merged 2-day emergency must still report the event."""
+        api = YasnoApi(region_id=1, provider_id=1)
+        day1 = date(2026, 7, 1)
+        merged = PlannedOutageEvent(
+            start=day1,
+            end=day1 + timedelta(days=2),
+            all_day=True,
+            event_type=PlannedOutageEventType.EMERGENCY,
+        )
+        api.get_events = MagicMock(return_value=[merged])
+
+        at_day2 = datetime(2026, 7, 2, 12, 0, tzinfo=TZ_UA)
+        assert api.get_current_event(at_day2) is merged
+
+
+class TestUpdateTimestampTimezone:
+    """The DTEK 'update' stamp is Kyiv wall-clock time, not host-local time."""
+
+    def test_parse_update_dt_uses_kyiv_tz(self, monkeypatch):
+        """Parsing must not depend on the host timezone."""
+        monkeypatch.setenv("TZ", "America/New_York")
+        time_module.tzset()
+        try:
+            parsed = _parse_update_dt("01.07.2026 12:00")
+            assert parsed == datetime(2026, 7, 1, 12, 0, tzinfo=TZ_UA)
+        finally:
+            monkeypatch.undo()
+            time_module.tzset()


### PR DESCRIPTION
Four independent data-correctness defects, each with a failing-first regression test in `tests/test_schedule_data_correctness.py`. Full suite green, ruff clean.

## 1. Stale-data consent is dropped after setup (follow-up to #56)

The config flow pops `_stale_ack` ("flow-local flag, do not persist") and the coordinator always polls `fetch_data()` with the default `allow_stale_data=False`. So an entry the user explicitly set up against a stale source works only until the coordinator's API instance loses its data — after any HA restart the entry stays permanently empty, because the still-stale source is never adopted again despite the user's consent.

Fix: persist the acknowledgement as `allow_stale_data` in the entry data and pass it on every coordinator poll (options can override).

## 2. Overnight periods crash on the last day of a month (e-svitlo)

`end_datetime.replace(day=end_datetime.day + 1)` raises `ValueError` for e.g. a 23:00–04:00 period on Oct 31 / Feb 28; the surrounding `except` then silently drops the whole event. Fixed with `+ timedelta(days=1)`.

## 3. Multi-day all-day (emergency) events stop being "current" after day 1 (Yasno)

`_merge_adjacent_events` merges consecutive all-day emergency days into one multi-day event, but `get_current_event` matched all-day events with `event.start == at.date()` — true only on the first day. From day 2 the integration reported "normal" during an ongoing emergency. Fixed with a range check `start <= at.date() < end`.

## 4. DTEK `update` stamp parsed in host timezone

`_parse_update_dt` calls `.astimezone(UTC)` on a naive `strptime` result, interpreting the Kyiv wall-clock stamp in the host's local timezone (commonly UTC in Docker), skewing the 2-day freshness window by the host offset. Fixed with `.replace(tzinfo=TZ_UA)` — the same convention `common_tools.parse_timestamp` already uses for this format.
